### PR TITLE
Make `include_doc` usable from no_std crates

### DIFF
--- a/packages/include-doc/src/lib.rs
+++ b/packages/include-doc/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! Include Rust source files as doctests.
 //!
 //! # Examples


### PR DESCRIPTION
When compiling `include_doc` for a target that does no have std-support like armv7a-none-eabi, compilation failed because include_str is not used automatically without declaring `no_std`.

Macros that depend on std and are reexported from `include_doc` will be compiled for the host target (e.g. x86_64-unknown-linux-gnu) and can be used without issue.